### PR TITLE
Update license and readme after change to ARFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ Includes New Features, Enhancements, and Bug Fixes.
 
 * Changelog initialization (#26, #39, #40, #46, #47, #48, #50, #51, #52, #54)
 * .gitignore (#21, #34, #38)
-* Repo readme (#22, #57, #60)
+* Repo readme (#22, #57, #60, #64)
 * Abstract (#12)
 * Contributing document (#55)
 * Baseline readme (#62)
 * Scripts readme (#62)
+* Repo License (#64)
 
 ### Example
 Includes analysis notebooks.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Nathan Ryan
+Copyright (c) 2024, ARFC
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NEAR
-[![Changelog Check](https://github.com/nsryan2/NEAR/actions/workflows/changelog_test.yml/badge.svg)](https://github.com/nsryan2/NEAR/actions/workflows/changelog_test.yml)
+[![Changelog Check](https://github.com/arfc/NEAR/actions/workflows/changelog_test.yml/badge.svg)](https://github.com/arfc/NEAR/actions/workflows/changelog_test.yml)
 
 NEAR (Non-Equilibrium Archetypes of Reactors): Houses cyclus archetypes for non-equilibrium reactors with core-loading and enrichment variability.
 


### PR DESCRIPTION
This PR closes #63 and closes #58 by updating the name on the license and changing the tag for testing from nsryan2 to ARFC with the transfer of the repository. 