### PR TITLE
Trading On-Demand reactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Includes New Features, Enhancements, and Bug Fixes.
 * Install script (#23, #24)
 * Start CLOVER (#8, #16)
 * Create DPR (#65)
+* Create TOD Reactor (#66)
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Houses the Dynamic Power Reactor (DPR) archetype. DPR is based on the Cyclus v.1
 ## ./EVER/
 Houses the Enrichment Versatile non-Equilibrium Reactor (EVER), a generic Cyclus archetype that has the capability to update the recipe of fuel in a reactor.
 
+## ./TOD/
+Houses the Trading On-Demand (TOD) Reactor archetype. TOD is based on the Cyclus v.1.6 Cycamore reactor archetype, but it skips the Tick and Tock parts of a time step if it is not ready to accept more fuel.
+
 ## ./writing/
 This folder contains the writing on this project, and is governed by the license therein.
 

--- a/TOD/README.md
+++ b/TOD/README.md
@@ -1,0 +1,13 @@
+# Trading On-Demand (TOD) Reactor
+TOD is a Cyclus reactor archetype based on Cycamore's Reactor, except that it
+has the ability to update the power output over time. TOD achieves this by
+creating a private variable that is updated at the end of the Tock phase when
+the reactor refuels. Each intervening step checks if the current time step
+equals this private variable.
+
+> [!Note]
+> The user does not need to do anything to take advantage of this
+> functionality, and it cannot be turned off.
+
+## Cite this work
+Pending...

--- a/TOD/todreactor.cc
+++ b/TOD/todreactor.cc
@@ -1,0 +1,613 @@
+#include "todreactor.h"
+
+using cyclus::Material;
+using cyclus::toolkit::MatVec;
+using cyclus::KeyError;
+using cyclus::ValueError;
+using cyclus::Request;
+
+namespace cycamore {
+
+TODReactor::TODReactor(cyclus::Context* ctx)
+    : cyclus::Facility(ctx),
+      n_assem_batch(0),
+      assem_size(0),
+      n_assem_core(0),
+      n_assem_spent(0),
+      n_assem_fresh(0),
+      cycle_time(0),
+      refuel_time(0),
+      cycle_step(0),
+      power_cap(0),
+      power_name("power"),
+      discharged(false),
+      latitude(0.0),
+      longitude(0.0),
+      keep_packaging(true),
+      coordinates(latitude, longitude) {}
+
+
+#pragma cyclus def clone cycamore::TODReactor
+
+#pragma cyclus def schema cycamore::TODReactor
+
+#pragma cyclus def annotations cycamore::TODReactor
+
+#pragma cyclus def infiletodb cycamore::TODReactor
+
+#pragma cyclus def snapshot cycamore::TODReactor
+
+#pragma cyclus def snapshotinv cycamore::TODReactor
+
+#pragma cyclus def initinv cycamore::TODReactor
+
+void TODReactor::InitFrom(TODReactor* m) {
+  #pragma cyclus impl initfromcopy cycamore::TODReactor
+  cyclus::toolkit::CommodityProducer::Copy(m);
+}
+
+void TODReactor::InitFrom(cyclus::QueryableBackend* b) {
+  #pragma cyclus impl initfromdb cycamore::TODReactor
+
+  namespace tk = cyclus::toolkit;
+  tk::CommodityProducer::Add(tk::Commodity(power_name),
+                             tk::CommodInfo(power_cap, power_cap));
+
+  for (int i = 0; i < side_products.size(); i++) {
+    tk::CommodityProducer::Add(tk::Commodity(side_products[i]),
+                               tk::CommodInfo(side_product_quantity[i],
+                                              side_product_quantity[i]));
+  }
+}
+
+void TODReactor::EnterNotify() {
+  cyclus::Facility::EnterNotify();
+
+  // Set keep packaging parameter in all ResBufs
+  fresh.keep_packaging(keep_packaging);
+  core.keep_packaging(keep_packaging);
+  spent.keep_packaging(keep_packaging);
+
+  // If the user ommitted fuel_prefs, we set it to zeros for each fuel
+  // type.  Without this segfaults could occur - yuck.
+  if (fuel_prefs.size() == 0) {
+    for (int i = 0; i < fuel_outcommods.size(); i++) {
+      fuel_prefs.push_back(cyclus::kDefaultPref);
+    }
+  }
+
+  // Test if any side products have been defined.
+  if (side_products.size() == 0){
+    hybrid_ = false;
+  }
+
+  // input consistency checking:
+  int n = recipe_change_times.size();
+  std::stringstream ss;
+  if (recipe_change_commods.size() != n) {
+    ss << "prototype '" << prototype() << "' has "
+       << recipe_change_commods.size()
+       << " recipe_change_commods vals, expected " << n << "\n";
+  }
+  if (recipe_change_in.size() != n) {
+    ss << "prototype '" << prototype() << "' has " << recipe_change_in.size()
+       << " recipe_change_in vals, expected " << n << "\n";
+  }
+  if (recipe_change_out.size() != n) {
+    ss << "prototype '" << prototype() << "' has " << recipe_change_out.size()
+       << " recipe_change_out vals, expected " << n << "\n";
+  }
+
+  n = pref_change_times.size();
+  if (pref_change_commods.size() != n) {
+    ss << "prototype '" << prototype() << "' has " << pref_change_commods.size()
+       << " pref_change_commods vals, expected " << n << "\n";
+  }
+  if (pref_change_values.size() != n) {
+    ss << "prototype '" << prototype() << "' has " << pref_change_values.size()
+       << " pref_change_values vals, expected " << n << "\n";
+  }
+
+  if (ss.str().size() > 0) {
+    throw ValueError(ss.str());
+  }
+  RecordPosition();
+}
+
+bool TODReactor::CheckDecommissionCondition() {
+  return core.count() == 0 && spent.count() == 0;
+}
+
+void TODReactor::Tick() {
+  // The following code must go in the Tick so they fire on the time step
+  // following the cycle_step update - allowing for the all reactor events to
+  // occur and be recorded on the "beginning" of a time step.  Another reason
+  // they
+  // can't go at the beginnin of the Tock is so that resource exchange has a
+  // chance to occur after the discharge on this same time step.
+  double current_time = context()->time();
+  if (current_time < next_refuel_time_) {
+      // std::cout << "Skipping tick at time " << current_time
+      //           << " (Next refuel at " << next_refuel_time_ << ")\n";
+      return;
+  }
+  else{
+    if (retired()) {
+      Record("RETIRED", "");
+
+      if (context()->time() == exit_time() + 1) { // only need to transmute once
+        if (decom_transmute_all == true) {
+          Transmute(ceil(static_cast<double>(n_assem_core)));
+        }
+        else {
+          Transmute(ceil(static_cast<double>(n_assem_core) / 2.0));
+        }
+      }
+      while (core.count() > 0) {
+        if (!Discharge()) {
+          break;
+        }
+      }
+      // in case a cycle lands exactly on our last time step, we will need to
+      // burn a batch from fresh inventory on this time step.  When retired,
+      // this batch also needs to be discharged to spent fuel inventory.
+      while (fresh.count() > 0 && spent.space() >= assem_size) {
+        spent.Push(fresh.Pop());
+      }
+      if(CheckDecommissionCondition()) {
+        context()->SchedDecom(this);
+      }
+      return;
+    }
+
+    if (cycle_step == cycle_time) {
+      Transmute();
+      Record("CYCLE_END", "");
+    }
+
+    if (cycle_step >= cycle_time && !discharged) {
+      discharged = Discharge();
+    }
+    if (cycle_step >= cycle_time) {
+      Load();
+    }
+
+    int t = context()->time();
+
+    // update preferences
+    for (int i = 0; i < pref_change_times.size(); i++) {
+      int change_t = pref_change_times[i];
+      if (t != change_t) {
+        continue;
+      }
+
+      std::string incommod = pref_change_commods[i];
+      for (int j = 0; j < fuel_incommods.size(); j++) {
+        if (fuel_incommods[j] == incommod) {
+          fuel_prefs[j] = pref_change_values[i];
+          break;
+        }
+      }
+    }
+
+    // update recipes
+    for (int i = 0; i < recipe_change_times.size(); i++) {
+      int change_t = recipe_change_times[i];
+      if (t != change_t) {
+        continue;
+      }
+
+      std::string incommod = recipe_change_commods[i];
+      for (int j = 0; j < fuel_incommods.size(); j++) {
+        if (fuel_incommods[j] == incommod) {
+          fuel_inrecipes[j] = recipe_change_in[i];
+          fuel_outrecipes[j] = recipe_change_out[i];
+          break;
+        }
+      }
+    }
+  }
+}
+
+std::set<cyclus::RequestPortfolio<Material>::Ptr> TODReactor::GetMatlRequests() {
+  using cyclus::RequestPortfolio;
+
+  std::set<RequestPortfolio<Material>::Ptr> ports;
+  Material::Ptr m;
+
+  // second min expression reduces assembles to amount needed until
+  // retirement if it is near.
+  int n_assem_order = n_assem_core - core.count() + n_assem_fresh - fresh.count();
+
+  if (exit_time() != -1) {
+    // the +1 accounts for the fact that the reactor is alive and gets to
+    // operate during its exit_time time step.
+    int t_left = exit_time() - context()->time() + 1;
+    int t_left_cycle = cycle_time + refuel_time - cycle_step;
+    double n_cycles_left = static_cast<double>(t_left - t_left_cycle) /
+                         static_cast<double>(cycle_time + refuel_time);
+    n_cycles_left = ceil(n_cycles_left);
+    int n_need = std::max(0.0, n_cycles_left * n_assem_batch - n_assem_fresh + n_assem_core - core.count());
+    n_assem_order = std::min(n_assem_order, n_need);
+  }
+
+  if (n_assem_order == 0) {
+    return ports;
+  } else if (retired()) {
+    return ports;
+  }
+
+  for (int i = 0; i < n_assem_order; i++) {
+    RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
+    std::vector<Request<Material>*> mreqs;
+    for (int j = 0; j < fuel_incommods.size(); j++) {
+      std::string commod = fuel_incommods[j];
+      double pref = fuel_prefs[j];
+      cyclus::Composition::Ptr recipe = context()->GetRecipe(fuel_inrecipes[j]);
+      m = Material::CreateUntracked(assem_size, recipe);
+
+      Request<Material>* r = port->AddRequest(m, this, commod, pref, true);
+      mreqs.push_back(r);
+    }
+
+    std::vector<double>::iterator result;
+    result = std::max_element(fuel_prefs.begin(), fuel_prefs.end());
+    int max_index = std::distance(fuel_prefs.begin(), result);
+
+    cyclus::toolkit::RecordTimeSeries<double>("demand"+fuel_incommods[max_index], this,
+                                          assem_size) ;
+
+    port->AddMutualReqs(mreqs);
+    ports.insert(port);
+  }
+
+  return ports;
+}
+
+void TODReactor::GetMatlTrades(
+    const std::vector<cyclus::Trade<Material> >& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+        responses) {
+  using cyclus::Trade;
+
+  std::map<std::string, MatVec> mats = PopSpent();
+  for (int i = 0; i < trades.size(); i++) {
+    std::string commod = trades[i].request->commodity();
+    Material::Ptr m = mats[commod].back();
+    mats[commod].pop_back();
+    responses.push_back(std::make_pair(trades[i], m));
+    res_indexes.erase(m->obj_id());
+  }
+  PushSpent(mats);  // return leftovers back to spent buffer
+}
+
+void TODReactor::AcceptMatlTrades(const std::vector<
+    std::pair<cyclus::Trade<Material>, Material::Ptr> >& responses) {
+  std::vector<std::pair<cyclus::Trade<Material>,
+                        Material::Ptr> >::const_iterator trade;
+
+  std::stringstream ss;
+  int nload = std::min((int)responses.size(), n_assem_core - core.count());
+  if (nload > 0) {
+    ss << nload << " assemblies";
+    Record("LOAD", ss.str());
+  }
+
+  for (trade = responses.begin(); trade != responses.end(); ++trade) {
+    std::string commod = trade->first.request->commodity();
+    Material::Ptr m = trade->second;
+    index_res(m, commod);
+
+    if (core.count() < n_assem_core) {
+      core.Push(m);
+    } else {
+      fresh.Push(m);
+    }
+  }
+}
+
+std::set<cyclus::BidPortfolio<Material>::Ptr> TODReactor::GetMatlBids(
+    cyclus::CommodMap<Material>::type& commod_requests) {
+  using cyclus::BidPortfolio;
+  std::set<BidPortfolio<Material>::Ptr> ports;
+
+  bool gotmats = false;
+  std::map<std::string, MatVec> all_mats;
+
+  if (uniq_outcommods_.empty()) {
+    for (int i = 0; i < fuel_outcommods.size(); i++) {
+      uniq_outcommods_.insert(fuel_outcommods[i]);
+    }
+  }
+
+  std::set<std::string>::iterator it;
+  for (it = uniq_outcommods_.begin(); it != uniq_outcommods_.end(); ++it) {
+    std::string commod = *it;
+    std::vector<Request<Material>*>& reqs = commod_requests[commod];
+    if (reqs.size() == 0) {
+      continue;
+    } else if (!gotmats) {
+      all_mats = PeekSpent();
+    }
+
+    MatVec mats = all_mats[commod];
+    if (mats.size() == 0) {
+      continue;
+    }
+
+    BidPortfolio<Material>::Ptr port(new BidPortfolio<Material>());
+
+    for (int j = 0; j < reqs.size(); j++) {
+      Request<Material>* req = reqs[j];
+      double tot_bid = 0;
+      for (int k = 0; k < mats.size(); k++) {
+        Material::Ptr m = mats[k];
+        tot_bid += m->quantity();
+        port->AddBid(req, m, this, true);
+        if (tot_bid >= req->target()->quantity()) {
+          break;
+        }
+      }
+    }
+
+    double tot_qty = 0;
+    for (int j = 0; j < mats.size(); j++) {
+      tot_qty += mats[j]->quantity();
+    }
+
+    cyclus::CapacityConstraint<Material> cc(tot_qty);
+    port->AddConstraint(cc);
+    ports.insert(port);
+  }
+
+  return ports;
+}
+
+void TODReactor::Tock() {
+  if (retired()) {
+    return;
+  }
+
+  // Check that irradiation and refueling periods are over, that
+  // the core is full and that fuel was successfully discharged in this refueling time.
+  // If this is the case, then a new cycle will be initiated.
+  if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core && discharged == true) {
+    discharged = false;
+    cycle_step = 0;
+  }
+
+  if (cycle_step == 0 && core.count() == n_assem_core) {
+    Record("CYCLE_START", "");
+  }
+
+  if (cycle_step >= 0 && cycle_step < cycle_time &&
+      core.count() == n_assem_core) {
+    cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, power_cap);
+    cyclus::toolkit::RecordTimeSeries<double>("supplyPOWER", this, power_cap);
+    RecordSideProduct(true);
+  } else {
+    cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, 0);
+    cyclus::toolkit::RecordTimeSeries<double>("supplyPOWER", this, 0);
+    RecordSideProduct(false);
+  }
+
+  // "if" prevents starting cycle after initial deployment until core is full
+  // even though cycle_step is its initial zero.
+  if (cycle_step > 0 || core.count() == n_assem_core) {
+    cycle_step++;
+  }
+
+  // Calculate when the next refuel will occur
+   double current_time = context()->time();
+   double next_refuel = 0;
+   if (current_time >= next_refuel_time_) {
+      // Trigger refueling behavior here (e.g., start refuel process)
+      next_refuel = current_time + cycle_time + refuel_time;  // Set next refuel time
+      if (next_refuel < exit_time()) {
+        next_refuel_time_ = next_refuel ;
+      }
+      else {
+        next_refuel_time_ = 0 ;
+        return;
+      }
+   } else {
+      // Skip the tick and tock for this cycle until next refuel time is met
+      return;  // This skips the current tick and tock cycle
+   }
+}
+
+void TODReactor::Transmute() { Transmute(n_assem_batch); }
+
+void TODReactor::Transmute(int n_assem) {
+  MatVec old = core.PopN(std::min(n_assem, core.count()));
+  core.Push(old);
+  if (core.count() > old.size()) {
+    // rotate untransmuted mats back to back of buffer
+    core.Push(core.PopN(core.count() - old.size()));
+  }
+
+  std::stringstream ss;
+  ss << old.size() << " assemblies";
+  Record("TRANSMUTE", ss.str());
+
+  for (int i = 0; i < old.size(); i++) {
+    old[i]->Transmute(context()->GetRecipe(fuel_outrecipe(old[i])));
+  }
+}
+
+std::map<std::string, MatVec> TODReactor::PeekSpent() {
+  std::map<std::string, MatVec> mapped;
+  MatVec mats = spent.PopN(spent.count());
+  spent.Push(mats);
+  for (int i = 0; i < mats.size(); i++) {
+    std::string commod = fuel_outcommod(mats[i]);
+    mapped[commod].push_back(mats[i]);
+  }
+  return mapped;
+}
+
+bool TODReactor::Discharge() {
+  int npop = std::min(n_assem_batch, core.count());
+  if (n_assem_spent - spent.count() < npop) {
+    Record("DISCHARGE", "failed");
+    return false;  // not enough room in spent buffer
+  }
+
+  std::stringstream ss;
+  ss << npop << " assemblies";
+  Record("DISCHARGE", ss.str());
+  spent.Push(core.PopN(npop));
+
+  std::map<std::string, MatVec> spent_mats;
+  for (int i = 0; i < fuel_outcommods.size(); i++) {
+    spent_mats = PeekSpent();
+    MatVec mats = spent_mats[fuel_outcommods[i]];
+    double tot_spent = 0;
+    for (int j = 0; j<mats.size(); j++){
+      Material::Ptr m = mats[j];
+      tot_spent += m->quantity();
+    }
+    cyclus::toolkit::RecordTimeSeries<double>("supply"+fuel_outcommods[i], this, tot_spent);
+  }
+
+  return true;
+}
+
+void TODReactor::Load() {
+  int n = std::min(n_assem_core - core.count(), fresh.count());
+  if (n == 0) {
+    return;
+  }
+
+  std::stringstream ss;
+  ss << n << " assemblies";
+  Record("LOAD", ss.str());
+  core.Push(fresh.PopN(n));
+}
+
+std::string TODReactor::fuel_incommod(Material::Ptr m) {
+  int i = res_indexes[m->obj_id()];
+  if (i >= fuel_incommods.size()) {
+    throw KeyError("cycamore::TODReactor - no incommod for material object");
+  }
+  return fuel_incommods[i];
+}
+
+std::string TODReactor::fuel_outcommod(Material::Ptr m) {
+  int i = res_indexes[m->obj_id()];
+  if (i >= fuel_outcommods.size()) {
+    throw KeyError("cycamore::TODReactor - no outcommod for material object");
+  }
+  return fuel_outcommods[i];
+}
+
+std::string TODReactor::fuel_inrecipe(Material::Ptr m) {
+  int i = res_indexes[m->obj_id()];
+  if (i >= fuel_inrecipes.size()) {
+    throw KeyError("cycamore::TODReactor - no inrecipe for material object");
+  }
+  return fuel_inrecipes[i];
+}
+
+std::string TODReactor::fuel_outrecipe(Material::Ptr m) {
+  int i = res_indexes[m->obj_id()];
+  if (i >= fuel_outrecipes.size()) {
+    throw KeyError("cycamore::TODReactor - no outrecipe for material object");
+  }
+  return fuel_outrecipes[i];
+}
+
+double TODReactor::fuel_pref(Material::Ptr m) {
+  int i = res_indexes[m->obj_id()];
+  if (i >= fuel_prefs.size()) {
+    return 0;
+  }
+  return fuel_prefs[i];
+}
+
+void TODReactor::index_res(cyclus::Resource::Ptr m, std::string incommod) {
+  for (int i = 0; i < fuel_incommods.size(); i++) {
+    if (fuel_incommods[i] == incommod) {
+      res_indexes[m->obj_id()] = i;
+      return;
+    }
+  }
+  throw ValueError(
+      "cycamore::TODReactor - received unsupported incommod material");
+}
+
+std::map<std::string, MatVec> TODReactor::PopSpent() {
+  MatVec mats = spent.PopN(spent.count());
+  std::map<std::string, MatVec> mapped;
+  for (int i = 0; i < mats.size(); i++) {
+    std::string commod = fuel_outcommod(mats[i]);
+    mapped[commod].push_back(mats[i]);
+  }
+
+  // needed so we trade away oldest assemblies first
+  std::map<std::string, MatVec>::iterator it;
+  for (it = mapped.begin(); it != mapped.end(); ++it) {
+    std::reverse(it->second.begin(), it->second.end());
+  }
+
+  return mapped;
+}
+
+void TODReactor::PushSpent(std::map<std::string, MatVec> leftover) {
+  std::map<std::string, MatVec>::iterator it;
+  for (it = leftover.begin(); it != leftover.end(); ++it) {
+    // undo reverse in PopSpent to make sure oldest assemblies come out first
+    std::reverse(it->second.begin(), it->second.end());
+    spent.Push(it->second);
+  }
+}
+
+void TODReactor::RecordSideProduct(bool produce){
+  if (hybrid_){
+    double value;
+    for (int i = 0; i < side_products.size(); i++) {
+      if (produce){
+          value = side_product_quantity[i];
+      }
+      else {
+          value = 0;
+      }
+
+      context()
+          ->NewDatum("TODReactorSideProducts")
+          ->AddVal("AgentId", id())
+          ->AddVal("Time", context()->time())
+          ->AddVal("Product", side_products[i])
+          ->AddVal("Value", value)
+          ->Record();
+    }
+  }
+}
+
+void TODReactor::Record(std::string name, std::string val) {
+  context()
+      ->NewDatum("TODReactorEvents")
+      ->AddVal("AgentId", id())
+      ->AddVal("Time", context()->time())
+      ->AddVal("Event", name)
+      ->AddVal("Value", val)
+      ->Record();
+}
+
+void TODReactor::RecordPosition() {
+  std::string specification = this->spec();
+  context()
+      ->NewDatum("AgentPosition")
+      ->AddVal("Spec", specification)
+      ->AddVal("Prototype", this->prototype())
+      ->AddVal("AgentId", id())
+      ->AddVal("Latitude", latitude)
+      ->AddVal("Longitude", longitude)
+      ->Record();
+}
+
+extern "C" cyclus::Agent* ConstructTODReactor(cyclus::Context* ctx) {
+  return new TODReactor(ctx);
+}
+
+}  // namespace cycamore

--- a/TOD/todreactor.h
+++ b/TOD/todreactor.h
@@ -1,0 +1,475 @@
+#ifndef CYCAMORE_SRC_TODREACTOR_H_
+#define CYCAMORE_SRC_TODREACTOR_H_
+
+#include "cyclus.h"
+#include "cycamore_version.h"
+
+namespace cycamore {
+
+/// Reactor is a simple, general reactor based on static compositional
+/// transformations to model fuel burnup.  The user specifies a set of input
+/// fuels and corresponding burnt compositions that fuel is transformed to when
+/// it is discharged from the core.  No incremental transmutation takes place.
+/// Rather, at the end of an operational cycle, the batch being discharged from
+/// the core is instantaneously transmuted from its original fresh fuel
+/// composition into its spent fuel form.
+///
+/// Each fuel is identified by a specific input commodity and has an associated
+/// input recipe (nuclide composition), output recipe, output commidity, and
+/// preference.  The preference identifies which input fuels are preferred when
+/// requesting.  Changes in these preferences can be specified as a function of
+/// time using the pref_change variables.  Changes in the input-output recipe
+/// compositions can also be specified as a function of time using the
+/// recipe_change variables.
+///
+/// The reactor treats fuel as individual assemblies that are never split,
+/// combined or otherwise treated in any non-discrete way.  Fuel is requested
+/// in full-or-nothing assembly sized quanta.  If real-world assembly modeling
+/// is unnecessary, parameters can be adjusted (e.g. n_assem_core, assem_size,
+/// n_assem_batch).  At the end of every cycle, a full batch is discharged from
+/// the core consisting of n_assem_batch assemblies of assem_size kg. The
+/// reactor also has a specifiable refueling time period following the end of
+/// each cycle at the end of which it will resume operation on the next cycle
+/// *if* it has enough fuel for a full core; otherwise it waits until it has
+/// enough fresh fuel assemblies.
+///
+/// In addition to its core, the reactor has an on-hand fresh fuel inventory
+/// and a spent fuel inventory whose capacities are specified by n_assem_fresh
+/// and n_assem_spent respectively.  Each time step the reactor will attempt to
+/// acquire enough fresh fuel to fill its fresh fuel inventory (and its core if
+/// the core isn't currently full).  If the fresh fuel inventory has zero
+/// capacity, fuel will be ordered just-in-time after the end of each
+/// operational cycle before the next begins.  If the spent fuel inventory
+/// becomes full, the reactor will halt operation at the end of the next cycle
+/// until there is more room.  Each time step, the reactor will try to trade
+/// away as much of its spent fuel inventory as possible.
+///
+/// When the reactor reaches the end of its lifetime, it will discharge all
+/// material from its core and trade away all its spent fuel as quickly as
+/// possible.  Full decommissioning will be delayed until all spent fuel is
+/// gone.  If the reactor has a full core when it is decommissioned (i.e. is
+/// mid-cycle) when the reactor is decommissioned, half (rounded up to nearest
+/// int) of its assemblies are transmuted to their respective burnt
+/// compositions.
+
+class TODReactor : public cyclus::Facility,
+  public cyclus::toolkit::CommodityProducer,
+  public cyclus::toolkit::Position {
+#pragma cyclus note { \
+"niche": "todreactor", \
+"doc": \
+  "TODReactor is a simple, general reactor based on static compositional" \
+  " transformations to model fuel burnup.  The user specifies a set of input" \
+  " fuels and corresponding burnt compositions that fuel is transformed to when" \
+  " it is discharged from the core.  No incremental transmutation takes place." \
+  " Rather, at the end of an operational cycle, the batch being discharged from" \
+  " the core is instantaneously transmuted from its original fresh fuel" \
+  " composition into its spent fuel form." \
+  "\n\n" \
+  "Each fuel is identified by a specific input commodity and has an associated" \
+  " input recipe (nuclide composition), output recipe, output commidity, and" \
+  " preference.  The preference identifies which input fuels are preferred when" \
+  " requesting.  Changes in these preferences can be specified as a function of" \
+  " time using the pref_change variables.  Changes in the input-output recipe" \
+  " compositions can also be specified as a function of time using the" \
+  " recipe_change variables." \
+  "\n\n" \
+  "The reactor treats fuel as individual assemblies that are never split," \
+  " combined or otherwise treated in any non-discrete way.  Fuel is requested" \
+  " in full-or-nothing assembly sized quanta.  If real-world assembly modeling" \
+  " is unnecessary, parameters can be adjusted (e.g. n_assem_core, assem_size," \
+  " n_assem_batch).  At the end of every cycle, a full batch is discharged from" \
+  " the core consisting of n_assem_batch assemblies of assem_size kg. The" \
+  " reactor also has a specifiable refueling time period following the end of" \
+  " each cycle at the end of which it will resume operation on the next cycle" \
+  " *if* it has enough fuel for a full core; otherwise it waits until it has" \
+  " enough fresh fuel assemblies." \
+  "\n\n" \
+  "In addition to its core, the reactor has an on-hand fresh fuel inventory" \
+  " and a spent fuel inventory whose capacities are specified by n_assem_fresh" \
+  " and n_assem_spent respectively.  Each time step the reactor will attempt to" \
+  " acquire enough fresh fuel to fill its fresh fuel inventory (and its core if" \
+  " the core isn't currently full).  If the fresh fuel inventory has zero" \
+  " capacity, fuel will be ordered just-in-time after the end of each" \
+  " operational cycle before the next begins.  If the spent fuel inventory" \
+  " becomes full, the reactor will halt operation at the end of the next cycle" \
+  " until there is more room.  Each time step, the reactor will try to trade" \
+  " away as much of its spent fuel inventory as possible." \
+  "\n\n" \
+  "When the reactor reaches the end of its lifetime, it will discharge all" \
+  " material from its core and trade away all its spent fuel as quickly as" \
+  " possible.  Full decommissioning will be delayed until all spent fuel is" \
+  " gone.  If the reactor has a full core when it is decommissioned (i.e. is" \
+  " mid-cycle) when the reactor is decommissioned, half (rounded up to nearest" \
+  " int) of its assemblies are transmuted to their respective burnt" \
+  " compositions." \
+  "", \
+}
+
+ public:
+  TODReactor(cyclus::Context* ctx);
+  virtual ~TODReactor(){};
+
+  virtual std::string version() { return CYCAMORE_VERSION; }
+
+  virtual void Tick();
+  virtual void Tock();
+  virtual void EnterNotify();
+  virtual bool CheckDecommissionCondition();
+
+  virtual void AcceptMatlTrades(const std::vector<std::pair<
+      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
+
+  virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
+  GetMatlRequests();
+
+  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
+      cyclus::CommodMap<cyclus::Material>::type& commod_requests);
+
+  virtual void GetMatlTrades(
+      const std::vector<cyclus::Trade<cyclus::Material> >& trades,
+      std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                            cyclus::Material::Ptr> >& responses);
+
+  #pragma cyclus decl
+
+ private:
+  double next_refuel_time_;  // Time when the todreactor needs to refuel next
+
+  std::string fuel_incommod(cyclus::Material::Ptr m);
+  std::string fuel_outcommod(cyclus::Material::Ptr m);
+  std::string fuel_inrecipe(cyclus::Material::Ptr m);
+  std::string fuel_outrecipe(cyclus::Material::Ptr m);
+  double fuel_pref(cyclus::Material::Ptr m);
+
+  bool retired() {
+    return exit_time() != -1 && context()->time() > exit_time();
+  }
+
+  /// Store fuel info index for the given resource received on incommod.
+  void index_res(cyclus::Resource::Ptr m, std::string incommod);
+
+  /// Discharge a batch from the core if there is room in the spent fuel
+  /// inventory.  Returns true if a batch was successfully discharged.
+  bool Discharge();
+
+  /// Top up core inventory as much as possible.
+  void Load();
+
+  /// Transmute the batch that is about to be discharged from the core to its
+  /// fully burnt state as defined by its outrecipe.
+  void Transmute();
+
+  /// Records production of side products from the reactor
+  void RecordSideProduct(bool produce);
+
+  /// Transmute the specified number of assemblies in the core to their
+  /// fully burnt state as defined by their outrecipe.
+  void Transmute(int n_assem);
+
+  /// Records a reactor event to the output db with the given name and note val.
+  void Record(std::string name, std::string val);
+
+  /// Complement of PopSpent - must be called with all materials passed that
+  /// were not traded away to other agents.
+  void PushSpent(std::map<std::string, cyclus::toolkit::MatVec> leftover);
+
+  /// Returns all spent assemblies indexed by outcommod - removing them from
+  /// the spent fuel buffer.
+  std::map<std::string, cyclus::toolkit::MatVec> PopSpent();
+
+  /// Returns all spent assemblies indexed by outcommod without removing them
+  /// from the spent fuel buffer.
+  std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
+
+  /////// fuel specifications /////////
+  #pragma cyclus var { \
+    "uitype": ["oneormore", "incommodity"], \
+    "uilabel": "Fresh Fuel Commodity List", \
+    "doc": "Ordered list of input commodities on which to requesting fuel.", \
+  }
+  std::vector<std::string> fuel_incommods;
+  #pragma cyclus var { \
+    "uitype": ["oneormore", "inrecipe"], \
+    "uilabel": "Fresh Fuel Recipe List", \
+    "doc": "Fresh fuel recipes to request for each of the given fuel input " \
+           "commodities (same order).", \
+  }
+  std::vector<std::string> fuel_inrecipes;
+
+  #pragma cyclus var { \
+    "default": [], \
+    "uilabel": "Fresh Fuel Preference List", \
+    "doc": "The preference for each type of fresh fuel requested corresponding"\
+           " to each input commodity (same order).  If no preferences are " \
+           "specified, 1.0 is used for all fuel " \
+           "requests (default).", \
+  }
+  std::vector<double> fuel_prefs;
+  #pragma cyclus var { \
+    "uitype": ["oneormore", "outcommodity"], \
+    "uilabel": "Spent Fuel Commodity List", \
+    "doc": "Output commodities on which to offer spent fuel originally " \
+           "received as each particular input commodity (same order)." \
+  }
+  std::vector<std::string> fuel_outcommods;
+  #pragma cyclus var {           \
+    "uitype": ["oneormore", "outrecipe"], \
+    "uilabel": "Spent Fuel Recipe List", \
+    "doc": "Spent fuel recipes corresponding to the given fuel input " \
+           "commodities (same order)." \
+           " Fuel received via a particular input commodity is transmuted to " \
+           "the recipe specified here after being burned during a cycle.", \
+  }
+  std::vector<std::string> fuel_outrecipes;
+
+  ///////////// recipe changes ///////////
+  #pragma cyclus var { \
+    "default": [], \
+    "uilabel": "Time to Change Fresh/Spent Fuel Recipe", \
+    "doc": "A time step on which to change the input-output recipe pair for " \
+           "a requested fresh fuel.", \
+  }
+  std::vector<int> recipe_change_times;
+  #pragma cyclus var { \
+    "default": [], \
+    "uilabel": "Commodity for Changed Fresh/Spent Fuel Recipe", \
+    "doc": "The input commodity indicating fresh fuel for which recipes will " \
+           "be changed. Same order as and direct correspondence to the " \
+           "specified recipe change times.", \
+    "uitype": ["oneormore", "incommodity"], \
+  }
+  std::vector<std::string> recipe_change_commods;
+  #pragma cyclus var { \
+    "default": [], \
+    "uilabel": "New Recipe for Fresh Fuel", \
+    "doc": "The new input recipe to use for this recipe change." \
+           " Same order as and direct correspondence to the specified recipe " \
+           "change times.", \
+    "uitype": ["oneormore", "inrecipe"], \
+  }
+  std::vector<std::string> recipe_change_in;
+  #pragma cyclus var { \
+    "default": [], \
+    "uilabel": "New Recipe for Spent Fuel", \
+    "doc": "The new output recipe to use for this recipe change." \
+           " Same order as and direct correspondence to the specified recipe " \
+           "change times.", \
+    "uitype": ["oneormore", "outrecipe"], \
+  }
+  std::vector<std::string> recipe_change_out;
+
+ //////////// inventory and core params ////////////
+  #pragma cyclus var { \
+    "doc": "Mass (kg) of a single assembly.", \
+    "uilabel": "Assembly Mass", \
+    "uitype": "range", \
+    "range": [1.0, 1e5], \
+    "units": "kg", \
+  }
+  double assem_size;
+
+  #pragma cyclus var { \
+    "uilabel": "Number of Assemblies per Batch", \
+    "doc": "Number of assemblies that constitute a single batch.  " \
+           "This is the number of assemblies discharged from the core fully " \
+           "burned each cycle."           \
+           "Batch size is equivalent to ``n_assem_batch / n_assem_core``.", \
+  }
+  int n_assem_batch;
+  #pragma cyclus var { \
+    "default": 3, \
+    "uilabel": "Number of Assemblies in Core", \
+    "uitype": "range", \
+    "range": [1,3], \
+    "doc": "Number of assemblies that constitute a full core.", \
+  }
+  int n_assem_core;
+  #pragma cyclus var { \
+    "default": 0, \
+    "uilabel": "Minimum Fresh Fuel Inventory", \
+    "uitype": "range", \
+    "range": [0,3], \
+    "units": "assemblies", \
+    "doc": "Number of fresh fuel assemblies to keep on-hand if possible.", \
+  }
+  int n_assem_fresh;
+  #pragma cyclus var { \
+    "default": 1000000000, \
+    "uilabel": "Maximum Spent Fuel Inventory", \
+    "uitype": "range", \
+    "range": [0, 1000000000], \
+    "units": "assemblies", \
+    "doc": "Number of spent fuel assemblies that can be stored on-site before" \
+           " reactor operation stalls.", \
+  }
+  int n_assem_spent;
+
+   ///////// cycle params ///////////
+  #pragma cyclus var { \
+    "default": 18, \
+    "doc": "The duration of a full operational cycle (excluding refueling " \
+           "time) in time steps.", \
+    "uilabel": "Cycle Length", \
+    "units": "time steps", \
+  }
+  int cycle_time;
+  #pragma cyclus var { \
+    "default": 1, \
+    "doc": "The duration of a full refueling period - the minimum time between"\
+           " the end of a cycle and the start of the next cycle.", \
+    "uilabel": "Refueling Outage Duration", \
+    "units": "time steps", \
+  }
+  int refuel_time;
+  #pragma cyclus var { \
+    "default": 0, \
+    "doc": "Number of time steps since the start of the last cycle." \
+           " Only set this if you know what you are doing", \
+    "uilabel": "Time Since Start of Last Cycle", \
+    "units": "time steps", \
+  }
+  int cycle_step;
+
+  //////////// power params ////////////
+  #pragma cyclus var { \
+    "default": 0, \
+    "doc": "Amount of electrical power the facility produces when operating " \
+           "normally.", \
+    "uilabel": "Nominal Reactor Power", \
+    "uitype": "range", \
+    "range": [0.0, 2000.00],  \
+    "units": "MWe", \
+  }
+  double power_cap;
+
+  #pragma cyclus var { \
+    "default": "power", \
+    "uilabel": "Power Commodity Name", \
+    "doc": "The name of the 'power' commodity used in conjunction with a " \
+           "deployment curve.", \
+  }
+  std::string power_name;
+
+  /////////// hybrid params ///////////
+
+  #pragma cyclus var { \
+    "uilabel": "Side Product from Reactor Plant", \
+    "default": [], \
+    "doc": "Ordered vector of side product the reactor produces with power", \
+  }
+  std::vector<std::string> side_products;
+
+  #pragma cyclus var { \
+    "uilabel": "Quantity of Side Product from Reactor Plant", \
+    "default": [], \
+    "doc": "Ordered vector of the quantity of side product the reactor produces with power", \
+  }
+  std::vector<double> side_product_quantity;
+
+  #pragma cyclus var {"default": 1,\
+                      "internal": True,\
+                      "doc": "True if reactor is a hybrid system (produces side products)", \
+  }
+  bool hybrid_;
+
+
+  /////////// Decommission transmutation behavior ///////////
+  #pragma cyclus var {"default": 0, \
+                      "uilabel": "Boolean for transmutation behavior upon decommissioning.", \
+                      "doc": "If true, the archetype transmutes all assemblies upon decommissioning " \
+                             "If false, the archetype only transmutes half.", \
+  }
+  bool decom_transmute_all;
+
+
+  /////////// preference changes ///////////
+  #pragma cyclus var { \
+    "default": [], \
+    "uilabel": "Time to Change Fresh Fuel Preference", \
+    "doc": "A time step on which to change the request preference for a " \
+           "particular fresh fuel type.", \
+  }
+  std::vector<int> pref_change_times;
+  #pragma cyclus var { \
+    "default": [], \
+    "doc": "The input commodity for a particular fuel preference change.  " \
+           "Same order as and direct correspondence to the specified " \
+           "preference change times.", \
+    "uilabel": "Commodity for Changed Fresh Fuel Preference", \
+    "uitype": ["oneormore", "incommodity"], \
+  }
+  std::vector<std::string> pref_change_commods;
+  #pragma cyclus var { \
+    "default": [], \
+    "uilabel": "Changed Fresh Fuel Preference",                        \
+    "doc": "The new/changed request preference for a particular fresh fuel." \
+           " Same order as and direct correspondence to the specified " \
+           "preference change times.", \
+  }
+  std::vector<double> pref_change_values;
+
+  #pragma cyclus var { \
+    "default": True, \
+    "tooltip": "Whether to persist packaging throughout the reactor", \
+    "doc": "Boolean value about whether to keep packaging. If true, " \
+           "packaging will not be stripped upon acceptance into the " \
+           "reactor. If false, package type will be stripped immediately " \
+           "upon acceptance. Has no effect if the incoming material is not " \
+           "packaged.", \
+    "uilabel": "Keep Packaging", \
+    "uitype": "bool"}
+  bool keep_packaging;
+
+  // Resource inventories - these must be defined AFTER/BELOW the member vars
+  // referenced (e.g. n_batch_fresh, assem_size, etc.).
+  #pragma cyclus var {"capacity": "n_assem_fresh * assem_size"}
+  cyclus::toolkit::ResBuf<cyclus::Material> fresh;
+  #pragma cyclus var {"capacity": "n_assem_core * assem_size"}
+  cyclus::toolkit::ResBuf<cyclus::Material> core;
+  #pragma cyclus var {"capacity": "n_assem_spent * assem_size"}
+  cyclus::toolkit::ResBuf<cyclus::Material> spent;
+
+
+  // should be hidden in ui (internal only). True if fuel has already been
+  // discharged this cycle.
+  #pragma cyclus var {"default": 0, "doc": "This should NEVER be set manually",\
+                      "internal": True \
+  }
+  bool discharged;
+
+  // This variable should be hidden/unavailable in ui.  Maps resource object
+  // id's to the index for the incommod through which they were received.
+  #pragma cyclus var {"default": {}, "doc": "This should NEVER be set manually", \
+                      "internal": True \
+  }
+  std::map<int, int> res_indexes;
+
+  // populated lazily and no need to persist.
+  std::set<std::string> uniq_outcommods_;
+
+  #pragma cyclus var { \
+    "default": 0.0, \
+    "uilabel": "Geographical latitude in degrees as a double", \
+    "doc": "Latitude of the agent's geographical position. The value should " \
+           "be expressed in degrees as a double." \
+  }
+  double latitude;
+
+  #pragma cyclus var { \
+    "default": 0.0, \
+    "uilabel": "Geographical longitude in degrees as a double", \
+    "doc": "Longitude of the agent's geographical position. The value should " \
+           "be expressed in degrees as a double." \
+  }
+  double longitude;
+
+  cyclus::toolkit::Position coordinates;
+
+  /// Records an agent's latitude and longitude to the output db
+  void RecordPosition();
+};
+
+} // namespace cycamore
+
+#endif  // CYCAMORE_SRC_TODREACTOR_H_

--- a/TOD/todreactor_tests.cc
+++ b/TOD/todreactor_tests.cc
@@ -1,0 +1,762 @@
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+#include "cyclus.h"
+
+using pyne::nucname::id;
+using cyclus::Composition;
+using cyclus::Material;
+using cyclus::QueryResult;
+using cyclus::Cond;
+using cyclus::toolkit::MatQuery;
+
+namespace cycamore {
+namespace todreactortests {
+
+Composition::Ptr c_uox() {
+  cyclus::CompMap m;
+  m[id("u235")] = 0.04;
+  m[id("u238")] = 0.96;
+  return Composition::CreateFromMass(m);
+};
+
+Composition::Ptr c_mox() {
+  cyclus::CompMap m;
+  m[id("u235")] = .7;
+  m[id("u238")] = 100;
+  m[id("pu239")] = 3.3;
+  return Composition::CreateFromMass(m);
+};
+
+Composition::Ptr c_spentuox() {
+  cyclus::CompMap m;
+  m[id("u235")] =  .8;
+  m[id("u238")] =  100;
+  m[id("pu239")] = 1;
+  return Composition::CreateFromMass(m);
+};
+
+Composition::Ptr c_spentmox() {
+  cyclus::CompMap m;
+  m[id("u235")] =  .2;
+  m[id("u238")] =  100;
+  m[id("pu239")] = .9;
+  return Composition::CreateFromMass(m);
+};
+
+Composition::Ptr c_water() {
+  cyclus::CompMap m;
+  m[id("O16")] =  1;
+  m[id("H1")] =  2;
+  return Composition::CreateFromAtom(m);
+};
+
+// Test that with a zero refuel_time and a zero capacity fresh fuel buffer
+// (the default), fuel can be ordered and the cycle started with no time step
+// delay.
+TEST(TODReactorTests, JustInTimeOrdering) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddRecipe("lwr_fresh", c_uox());
+  sim.AddRecipe("lwr_spent", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("Transactions", NULL);
+  EXPECT_EQ(simdur, qr.rows.size()) << "failed to order+run on fresh fuel inside 1 time step";
+}
+
+// tests that the correct number of assemblies are popped from the core each
+// cycle.
+TEST(TODReactorTests, BatchSizes) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>7</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  ";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("Transactions", NULL);
+  // 7 for initial core, 3 per time step for each new batch for remainder
+  EXPECT_EQ(7+3*(simdur-1), qr.rows.size());
+}
+
+// tests that the refueling period between cycle end and start of the next
+// cycle is honored.
+TEST(TODReactorTests, RefuelTimes) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>4</cycle_time>  "
+     "  <refuel_time>3</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
+
+  int simdur = 49;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("Transactions", NULL);
+  int cyclet = 4;
+  int refuelt = 3;
+  int n_assem_want = simdur/(cyclet+refuelt)+1; // +1 for initial core
+  EXPECT_EQ(n_assem_want, qr.rows.size());
+}
+
+
+// tests that a TODReactor decommissions on time without producing
+// power at the end of its lifetime.
+TEST(TODReactorTests, DecomTimes) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>2</cycle_time>  "
+     "  <refuel_time>2</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <power_cap>1000</power_cap>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
+
+  int simdur = 12;
+  int lifetime = 7;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur, lifetime);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  // operating for 2+2 months and shutdown for 2+1
+  int on_time = 4;
+  std::vector<Cond> conds;
+  conds.push_back(Cond("Value", "==", 1000));
+  QueryResult qr = sim.db().Query("TimeSeriesPower", &conds);
+  EXPECT_EQ(on_time, qr.rows.size());
+
+  int off_time = 3;
+  conds.clear();
+  conds.push_back(Cond("Value", "==", 0));
+  qr = sim.db().Query("TimeSeriesPower", &conds);
+  EXPECT_EQ(off_time, qr.rows.size());
+}
+
+
+// Tests if a TODReactor produces power at the time of its decommission
+// given a refuel_time of zero.
+TEST(TODReactorTests, DecomZeroRefuel) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>2</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <power_cap>1000</power_cap>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
+
+  int simdur = 8;
+  int lifetime = 6;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur, lifetime);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  // operating for 2+2 months and shutdown for 2+1
+  int on_time = 6;
+  std::vector<Cond> conds;
+  conds.push_back(Cond("Value", "==", 1000));
+  QueryResult qr = sim.db().Query("TimeSeriesPower", &conds);
+  EXPECT_EQ(on_time, qr.rows.size());
+}
+
+// tests that new fuel is ordered immediately following cycle end - at the
+// start of the refueling period - not before and not after. - thie is subtly
+// different than RefuelTimes test and is not a duplicate of it.
+TEST(TODReactorTests, OrderAtRefuelStart) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>4</cycle_time>  "
+     "  <refuel_time>3</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
+
+  int simdur = 7;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("Transactions", NULL);
+  int cyclet = 4;
+  int refuelt = 3;
+  int n_assem_want = simdur/(cyclet+refuelt)+1; // +1 for initial core
+  EXPECT_EQ(n_assem_want, qr.rows.size());
+}
+
+// tests that the TODReactor handles requesting multiple types of fuel correctly
+// - with proper inventory constraint honoring, etc.
+TEST(TODReactorTests, MultiFuelMix) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_fresh>3</n_assem_fresh>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  ";
+
+  // it is important that the sources have cumulative capacity greater than
+  // the TODReactor can take on a single time step - to test that inventory
+  // capacity constraints are being set properly.  It is also important that
+  // each source is smaller capacity thatn the TODReactor orders on each time
+  // step to make it easy to compute+check the number of transactions.
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").capacity(2).Finalize();
+  sim.AddSource("mox").capacity(2).Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  sim.AddRecipe("mox", c_spentuox());
+  sim.AddRecipe("spentmox", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("Transactions", NULL);
+  // +3 is for fresh fuel inventory
+  EXPECT_EQ(3*simdur+3, qr.rows.size());
+}
+
+// tests that the TODReactor halts operation when it has no more room in its
+// spent fuel inventory buffer.
+TEST(TODReactorTests, FullSpentInventory) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     "  <n_assem_spent>3</n_assem_spent>  ";
+
+  int simdur = 10;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("Transactions", NULL);
+  int n_assem_spent = 3;
+
+  // +1 is for the assembly in the core + the three in spent
+  EXPECT_EQ(n_assem_spent+1, qr.rows.size());
+}
+
+// tests that the TODReactor shuts down, ie., does not generate power, when the
+// spent fuel inventory is full and the core cannot be unloaded.
+TEST(TODReactorTests, FullSpentInventoryShutdown) {
+  std::string config =
+    " <fuel_inrecipes> <val>uox</val> </fuel_inrecipes> "
+    " <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes> "
+    " <fuel_incommods> <val>uox</val> </fuel_incommods> "
+    " <fuel_outcommods> <val>waste</val> </fuel_outcommods> "
+    ""
+    " <cycle_time>1</cycle_time> "
+    " <refuel_time>0</refuel_time> "
+    " <assem_size>1</assem_size> "
+    " <n_assem_core>1</n_assem_core> "
+    " <n_assem_batch>1</n_assem_batch> "
+    " <n_assem_spent>1</n_assem_spent> "
+    " <power_cap>100</power_cap> ";
+
+  int simdur = 3;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("TimeSeriesPower", NULL);
+  EXPECT_EQ(0, qr.GetVal<double>("Value", simdur - 1));
+
+}
+
+// tests that the TODReactor cycle is delayed as expected when it is unable to
+// acquire fuel in time for the next cycle start.  This checks that after a
+// cycle is delayed past an original scheduled start time, as soon as enough fuel is
+// received, a new cycle pattern is established starting from the delayed
+// start time.
+TEST(TODReactorTests, FuelShortage) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>7</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  ";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").lifetime(1).Finalize(); // provide initial full batch
+  sim.AddSource("uox").start(9).lifetime(1).capacity(2).Finalize(); // provide partial batch post cycle-end
+  sim.AddSource("uox").start(15).Finalize(); // provide remainder of batch much later
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  // check that we never got a full refueled batch during refuel period
+  std::vector<Cond> conds;
+  conds.push_back(Cond("Time", "<", 15));
+  QueryResult qr = sim.db().Query("Transactions", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
+  // after being delayed past original scheduled start of new cycle, we got
+  // final assembly for core.
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 15));
+  qr = sim.db().Query("Transactions", &conds);
+  EXPECT_EQ(1, qr.rows.size());
+
+  // all during the next (delayed) cycle we shouldn't be requesting any new fuel
+  conds.clear();
+  conds.push_back(Cond("Time", "<", 21));
+  qr = sim.db().Query("Transactions", &conds);
+  EXPECT_EQ(6, qr.rows.size());
+
+  // as soon as this delayed cycle ends, we should be requesting/getting 3 new batches
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 22));
+  qr = sim.db().Query("Transactions", &conds);
+  EXPECT_EQ(3, qr.rows.size());
+}
+
+// tests that discharged fuel is transmuted properly immediately at cycle end.
+TEST(TODReactorTests, DischargedFuelTransmute) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>4</cycle_time>  "
+     "  <refuel_time>3</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
+
+  int simdur = 7;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddSink("waste").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  Composition::Ptr spentuox = c_spentuox();
+  sim.AddRecipe("spentuox", spentuox);
+  int id = sim.Run();
+
+  std::vector<Cond> conds;
+  conds.push_back(Cond("SenderId", "==", id));
+  int resid = sim.db().Query("Transactions", &conds).GetVal<int>("ResourceId");
+  Material::Ptr m = sim.GetMaterial(resid);
+  MatQuery mq(m);
+  EXPECT_EQ(spentuox->id(), m->comp()->id());
+  EXPECT_TRUE(mq.mass(942390000) > 0) << "transmuted spent fuel doesn't have Pu239";
+}
+
+// tests that spent fuel is offerred on correct commods according to the
+// incommod it was received on - esp when dealing with multiple fuel commods
+// simultaneously.
+TEST(TODReactorTests, SpentFuelProperCommodTracking) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste1</val>   <val>waste2</val>   </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  ";
+
+  int simdur = 7;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").capacity(1).Finalize();
+  sim.AddSource("mox").capacity(2).Finalize();
+  sim.AddSink("waste1").Finalize();
+  sim.AddSink("waste2").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  sim.AddRecipe("mox", c_mox());
+  sim.AddRecipe("spentmox", c_spentmox());
+  int id = sim.Run();
+
+  std::vector<Cond> conds;
+  conds.push_back(Cond("SenderId", "==", id));
+  conds.push_back(Cond("Commodity", "==", std::string("waste1")));
+  QueryResult qr = sim.db().Query("Transactions", &conds);
+  EXPECT_EQ(simdur-1, qr.rows.size());
+
+  conds[1] = Cond("Commodity", "==", std::string("waste2"));
+  qr = sim.db().Query("Transactions", &conds);
+  EXPECT_EQ(2*(simdur-1), qr.rows.size());
+}
+
+// The user can optionally omit fuel preferences.  In the case where
+// preferences are adjusted, the ommitted preference vector must be populated
+// with default values - if it wasn't then preferences won't be adjusted
+// correctly and the TODReactor could segfault.  Check that this doesn't happen.
+TEST(TODReactorTests, PrefChange) {
+  // it is important that the fuel_prefs not be present in the config below.
+  std::string config =
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     ""
+     "  <pref_change_times>   <val>25</val>         </pref_change_times>"
+     "  <pref_change_commods> <val>enriched_u</val> </pref_change_commods>"
+     "  <pref_change_values>  <val>-1</val>         </pref_change_values>";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddRecipe("lwr_fresh", c_uox());
+  sim.AddRecipe("lwr_spent", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("Transactions", NULL);
+  EXPECT_EQ(25, qr.rows.size()) << "failed to adjust preferences properly";
+}
+
+TEST(TODReactorTests, RecipeChange) {
+  // it is important that the fuel_prefs not be present in the config below.
+  std::string config =
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     ""
+     "  <recipe_change_times>   <val>25</val>         <val>35</val>         </recipe_change_times>"
+     "  <recipe_change_commods> <val>enriched_u</val> <val>enriched_u</val> </recipe_change_commods>"
+     "  <recipe_change_in>      <val>water</val>      <val>water</val>      </recipe_change_in>"
+     "  <recipe_change_out>     <val>lwr_spent</val>  <val>water</val>      </recipe_change_out>";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddSink("waste").Finalize();
+  sim.AddRecipe("lwr_fresh", c_uox());
+  sim.AddRecipe("lwr_spent", c_spentuox());
+  sim.AddRecipe("water", c_water());
+  int aid = sim.Run();
+
+  std::vector<Cond> conds;
+  QueryResult qr;
+
+  // check that received recipe is not water
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 24));
+  conds.push_back(Cond("ReceiverId", "==", aid));
+  qr = sim.db().Query("Transactions", &conds);
+  MatQuery mq = MatQuery(sim.GetMaterial(qr.GetVal<int>("ResourceId")));
+
+  EXPECT_TRUE(0 < mq.qty());
+  EXPECT_TRUE(0 == mq.mass(id("H1")));
+
+  // check that received recipe changed to water
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 26));
+  conds.push_back(Cond("ReceiverId", "==", aid));
+  qr = sim.db().Query("Transactions", &conds);
+  mq = MatQuery(sim.GetMaterial(qr.GetVal<int>("ResourceId")));
+
+  EXPECT_TRUE(0 < mq.qty());
+  EXPECT_TRUE(0 < mq.mass(id("H1")));
+
+  // check that sent recipe is not water
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 34));
+  conds.push_back(Cond("SenderId", "==", aid));
+  qr = sim.db().Query("Transactions", &conds);
+  mq = MatQuery(sim.GetMaterial(qr.GetVal<int>("ResourceId")));
+
+  EXPECT_TRUE(0 < mq.qty());
+  EXPECT_TRUE(0 == mq.mass(id("H1")));
+
+  // check that sent recipe changed to water
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 36));
+  conds.push_back(Cond("SenderId", "==", aid));
+  qr = sim.db().Query("Transactions", &conds);
+  mq = MatQuery(sim.GetMaterial(qr.GetVal<int>("ResourceId")));
+
+  EXPECT_TRUE(0 < mq.qty());
+  EXPECT_TRUE(0 < mq.mass(id("H1")));
+}
+
+TEST(TODReactorTests, Retire) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     ""
+     "  <cycle_time>7</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_fresh>1</n_assem_fresh>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     "  <power_cap>1</power_cap>  "
+     "";
+
+  int dur = 50;
+  int life = 36;
+  int cycle_time = 7;
+  int refuel_time = 0;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, dur, life);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddSink("waste").Finalize();
+  sim.AddRecipe("lwr_fresh", c_uox());
+  sim.AddRecipe("lwr_spent", c_spentuox());
+  int id = sim.Run();
+
+  int ncore = 3;
+  int nbatch = 1;
+
+  // TODReactor should stop requesting new fresh fuel as it approaches retirement
+  int nassem_recv =
+      static_cast<int>(ceil(static_cast<double>(life) / 7.0)) * nbatch +
+      (ncore - nbatch);
+
+  std::vector<Cond> conds;
+  conds.push_back(Cond("ReceiverId", "==", id));
+  QueryResult qr = sim.db().Query("Transactions", &conds);
+  EXPECT_EQ(nassem_recv, qr.rows.size())
+      << "failed to stop ordering near retirement";
+
+  // TODReactor should discharge all fuel before/by retirement
+  conds.clear();
+  conds.push_back(Cond("SenderId", "==", id));
+  qr = sim.db().Query("Transactions", &conds);
+  EXPECT_EQ(nassem_recv, qr.rows.size())
+      << "failed to discharge all material by retirement time";
+
+  // TODReactor should record power entry on the time step it retires if operating
+  int time_online = life / (cycle_time + refuel_time) * cycle_time + std::min(life % (cycle_time + refuel_time), cycle_time);
+  conds.clear();
+  conds.push_back(Cond("AgentId", "==", id));
+  conds.push_back(Cond("Value", ">", 0));
+  qr = sim.db().Query("TimeSeriesPower", &conds);
+  EXPECT_EQ(time_online, qr.rows.size())
+      << "failed to generate power for the correct number of time steps";
+}
+
+TEST(TODReactorTests, PositionInitialize) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddRecipe("lwr_fresh", c_uox());
+  sim.AddRecipe("lwr_spent", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("AgentPosition", NULL);
+  EXPECT_EQ(qr.GetVal<double>("Latitude"), 0.0);
+  EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.0);
+}
+
+TEST(TODReactorTests, PositionInitialize2) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     "  <longitude>30.0</longitude>  "
+     "  <latitude>30.0</latitude>  ";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddRecipe("lwr_fresh", c_uox());
+  sim.AddRecipe("lwr_spent", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("AgentPosition", NULL);
+  EXPECT_EQ(qr.GetVal<double>("Latitude"), 30.0);
+  EXPECT_EQ(qr.GetVal<double>("Longitude"), 30.0);
+}
+
+TEST(TODReactorTests, ByProduct) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>1</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>7</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  "
+     ""
+     "  <side_products> <val>process_heat</val> </side_products>"
+     "  <side_product_quantity> <val>10</val> </side_product_quantity>";
+
+  int simdur = 10;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  std::vector<Cond> conds;
+  // test if it produces side products only when TODReactor is running
+  int quantity = 10;
+  conds.push_back(Cond("Value", "==", quantity));
+  QueryResult qr = sim.db().Query("TODReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
+  // test if it doesn't produce side products when TODReactor is refueling
+  conds.clear();
+  conds.push_back(Cond("Value", "==", 0));
+  qr = sim.db().Query("TODReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+}
+
+TEST(TODReactorTests, MultipleByProduct) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>1</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>7</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  "
+     ""
+     "  <side_products> <val>process_heat</val> <val>water</val> </side_products>"
+     "  <side_product_quantity> <val>10</val> <val>100</val> </side_product_quantity>";
+
+  int simdur = 10;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:TODReactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+
+  std::vector<Cond> conds;
+  // test if it produces heat when TODReactor is running
+  int quantity = 10;
+  conds.push_back(Cond("Product", "==", std::string("process_heat")));
+  conds.push_back(Cond("Value", "==", quantity));
+  QueryResult qr = sim.db().Query("TODReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
+  // test if it produces water when TODReactor is running
+  conds.clear();
+  quantity = 100;
+  conds.push_back(Cond("Product", "==", std::string("water")));
+  conds.push_back(Cond("Value", "==", quantity));
+  qr = sim.db().Query("TODReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
+  conds.clear();
+  conds.push_back(Cond("Value", "==", 0));
+  qr = sim.db().Query("TODReactorSideProducts", &conds);
+  EXPECT_EQ(10, qr.rows.size());
+
+}
+
+} // namespace TODReactortests
+} // namespace cycamore


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting. -->
TOD is a Cyclus reactor archetype based on Cycamore's Reactor, except that it
has the ability to update the power output over time. TOD achieves this by
creating a private variable that is updated at the end of the Tock phase when
the reactor refuels. Each intervening step checks if the current time step
equals this private variable.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request. -->

- Issue: #


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->

- Dev: @


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.
